### PR TITLE
[finishes #163677251] added the delete party endpoint

### DIFF
--- a/app/api/v1/views/views.py
+++ b/app/api/v1/views/views.py
@@ -47,9 +47,32 @@ def get_a_party(party_id):
         return jsonify({"message":"party do not exists"}), 404
 
 
-@api.route('/parties/<int:id>', methods = ['DELETE'])
-def delete_a_party(id):
-    pass
+@api.route('/parties/<int:party_id>', methods = ['DELETE'])
+def delete_a_party(party_id):
+    if not isinstance(party_id, int):
+        return jsonify({"message": "ID must be an integer"}), 400
+    elif party_id < 0:
+        return jsonify({"message": "ID must not be a negative integer"}), 400
+    else:
+        for party in parties:
+            if party['id'] == party_id:
+                party_index = parties.index(party)
+                del(parties[party_index])
+                return jsonify({
+                    "status": 200,
+                    "data": [
+                        {
+                            "message": "party deleted successfully"
+                        }
+                    ]
+                }), 200
+        return jsonify({
+            "status":404,
+            "data": [{
+                "message": "party does not exists"
+            }]
+        }), 404
+
 
 @api.route('/parties/<int:party_id>/name', methods = ['PATCH'])
 def edit_a_party(party_id):

--- a/app/test/v1/unit/test_party.py
+++ b/app/test/v1/unit/test_party.py
@@ -52,21 +52,63 @@ class TestParty(TestCase):
         """Tests the getting of a specific party"""
         with self.app.test_client() as c:
             response = c.get("/api/v1/parties/1")
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, 200, msg="party was not found")
 
     def test_edit_party(self):
         """Tests that the API edit a party endpoint can edit a party"""
         with self.app.test_client() as c:
-            data = json.dumps(dict(
+            data = dict(
+                id=1,
+                name="Jubilee",
+                hqAddress="Jubilee House",
+                logoUrl="https:www.jubilee.co.ke/logo.png"
+            )
+            c.post("/api/v1/parties", data=json.dumps(data), content_type="application/json")
+            new_data = json.dumps(dict(
                 name = "New party name"
             ))
-            response =c.patch("/api/v1/parties/1/name", data=data, content_type="application/json")
-            self.assertEqual(response.status_code, 200)
+            response =c.patch("/api/v1/parties/1/name", data=new_data, content_type="application/json")
+            self.assertEqual(response.status_code, 200, msg="party edit failed")
             response_msg = json.loads(response.data.decode("UTF-8"))
             self.assertIn("status" , response_msg)
             self.assertEqual(response_msg["status"], 200)
             expected_party_data = response_msg["data"]
             self.assertListEqual(expected_party_data, [{"id":1, "name":"New party name"}])
+
+    def test_delete_party(self):
+        """Tests the delete part endpoint of the API"""
+        with self.app.test_client() as c:
+            data = dict(
+                id=1,
+                name="Jubilee",
+                hqAddress="Jubilee House",
+                logoUrl="https:www.jubilee.co.ke/logo.png"
+            )
+            c.post("/api/v1/parties", data=json.dumps(data), content_type="application/json")
+            response = c.delete("/api/v1/parties/1")
+            self.assertEqual(response.status_code, 200)
+            response_msg = json.loads(response.data.decode("UTF-8"))
+            self.assertIn("status", response_msg)
+            response_data = response_msg["data"]
+            self.assertListEqual(response_data, [{
+                            "message": "party deleted successfully"
+                        }])
+
+    def test_invalid_delete(self):
+        with self.app.test_client() as c:
+            response = c.delete("/api/v1/parties/10")
+            self.assertEqual(response.status_code, 404)
+            response_msg = json.loads(response.data.decode("UTF-8"))
+            self.assertIn("status", response_msg)
+            response_data = response_msg["data"]
+            self.assertListEqual(response_data, [{
+                "message": "party does not exists"
+            }])
+
+
+
+
+
 
      
 


### PR DESCRIPTION
**What does this PR do?**

-  adds the delete party endpoint and its associated unittests

**Description of tasks to be completed**

- Have the endpoint created `DELETE http://127.0.0.1/api/v1/parties/<party_id>`
- Fetch the party with the id sent via the `JSON `payload
- delete the party from  the list of parties
- return a response message
- write unittests for the endpoint

**How to manually test this**

- clone the repo
- do git checkout  `ft-deleteparty-#163677251`
- run the server using the command `python run.py`
- sent a DELETE request using postman to the specific party_id
