### PR TITLE
[finishes #163680405] Add the get a specific office endpoint

### DIFF
--- a/tests/test_office.py
+++ b/tests/test_office.py
@@ -25,3 +25,21 @@ class TestOffice(BaseTest):
             response_msg = json.loads(response.data.decode("UTF-8"))
             self.assertEqual(
                 response_msg["message"], "Office with that ID already exists")
+
+    def test_get_office(self):
+        with self.app_context():
+            response = self.app.get("/api/v1/offices/1")
+            self.assertEqual(response.status_code, 200,
+                             msg="Error office did not return 200 OK")
+            response_msg = json.loads(response.data.decode("UTF-8"))
+            self.assertListEqual(response_msg["data"], [{
+                "id": 1,
+                "type": "Local government",
+                "name": "Office of the MCA"
+            }])
+
+    def test_get_office_not_found(self):
+        with self.app_context():
+            response = self.app.get("/api/v1/1000")
+            self.assertEqual(response.status_code, 404,
+                             msg="Error get party not found dir not return 404")


### PR DESCRIPTION
**What does this PR do?**

- Creates the get a specific party endpoint and it associated tests

**Description of tasks to be done**

- Get the id of the office sent via request
- loop through the list of office and return the matching office
- If not found return error

**How to manually test this**
`clone` the repo
do `git checkout ft-getspecificoffice-#163680405`
run the server using the command `python run.py`
send a `GET` request with the id of the office in question

**Relevant pivotal tracker ids**

#163680405